### PR TITLE
use spatial default extent config setting in place of hard coded default extent for spatial map widget

### DIFF
--- a/ckanext/cioos_theme/templates/group/read.html
+++ b/ckanext/cioos_theme/templates/group/read.html
@@ -32,7 +32,7 @@
 {% block secondary_content %}
   {{ super() }}
 
-  {% snippet "spatial/snippets/spatial_query.html" , default_extent="[[48.0, -130.0], [60.0, -110.0]]", alternative_url=h.full_current_url() %}
+  {% snippet "spatial/snippets/spatial_query.html" , default_extent= h.spatial_default_extent(), alternative_url=h.full_current_url() %}
 
   <div class="filters">
     <div>

--- a/ckanext/cioos_theme/templates/package/search.html
+++ b/ckanext/cioos_theme/templates/package/search.html
@@ -73,7 +73,7 @@
 {% block secondary_content %}
 <div class="filters">
   <div>
-    {% snippet "spatial/snippets/spatial_query.html" , default_extent="[[48.0, -130.0], [60.0, -110.0]]" %}
+    {% snippet "spatial/snippets/spatial_query.html" , default_extent= h.spatial_default_extent() %}
     {% for facet in c.facet_titles %}
       {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet) }}
     {% endfor %}


### PR DESCRIPTION
Current the starting default extent of the spatial map widget is hard coded into the template. this will allow setting this via the production.ini config file.

example config entry:
`ckanext.spatial.default_extent = [[48.0, -110.0], [60.0, -50.0]]`

