### PR TITLE
add link to external organization home page url to sidebar

### DIFF
--- a/ckanext/cioos_theme/templates/snippets/organization.html
+++ b/ckanext/cioos_theme/templates/snippets/organization.html
@@ -47,6 +47,9 @@ Example:
       {% else %}
         <p class="empty">{{ _('There is no description for this organization') }}</p>
       {% endif %}
+      {% if organization.external_home_url %}
+        <a href="{{ organization.external_home_url }}" class="btn"><i class="fa fa-icon fa-link"></i>{{ _(' External Organization Page ')}}</a>
+      {% endif %}
       {% endblock %}
       {% if show_nums %}
         {% block nums %}


### PR DESCRIPTION
This change is combined with a change to the organization schema to include an external url entry.

Not sure if we need this but I have a note to add a link to an organizations external  home page.