### PR TITLE
Add exclude_eov and exclude_eov_category to config

### DIFF
--- a/ckanext/cioos_theme/plugin.py
+++ b/ckanext/cioos_theme/plugin.py
@@ -241,7 +241,10 @@ class Cioos_ThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
             'ckan.site_about': [ignore_missing, fluent_field_default(None, None), fluent_text(None, None)],
             'ckan.site_intro_text': [ignore_missing, fluent_field_default(None, None), fluent_text(None, None)],
             'ckan.site_logo_translated': [ignore_missing, fluent_field_default(None, None), fluent_text(None, None)],
-            'ckan.site_home_url': [ignore_missing, url_validator_with_port]
+            'ckan.site_home_url': [ignore_missing, url_validator_with_port],
+            'ckan.exclude_eov_category': [ignore_missing],
+            'ckan.exclude_eov': [ignore_missing],
+            'ckan.eov_icon_base_path': [ignore_missing]
 
         })
         return schema

--- a/ckanext/cioos_theme/templates/admin/config.html
+++ b/ckanext/cioos_theme/templates/admin/config.html
@@ -31,6 +31,9 @@
 
       {{ form.input('ckan.site_home_url', id='field-ckan-site-home-url', label=_('Site Landing Page'), value=data['ckan.site_home_url'], error=error) }}
 
+      {{ form.input('ckan.exclude_eov_category', id='field-ckan-exclude-eov-categoryl', label=_('Exclude eov\'s by category'), value=data['ckan.exclude_eov_category'], error=error) }}
+
+      {{ form.input('ckan.exclude_eov', id='field-ckan-exclude-eov', label=_('Exlcude individul eov\'s'), value=data['ckan.exclude_eov'], error=error) }}
       {% endblock %}
       <div class="form-actions">
         <a href="{% url_for 'admin.reset_config' %}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to reset the config?') }}">{{ _('Reset') }}</a>

--- a/ckanext/cioos_theme/templates/home/layout4.html
+++ b/ckanext/cioos_theme/templates/home/layout4.html
@@ -290,10 +290,11 @@
           <h3 class="heading">{{ _('SEARCH BY OCEAN VARIABLE') }}</h3>
           {% set eov = h.cioos_get_eovs(show_all=True) %}
           {% for grouper, list in eov|groupby('category') %}
-          {% if grouper %}
+          {% if grouper and grouper not in g.exclude_eov_category %}
           <h4>{{ _(grouper) }}</h4>
           <ul class="media-grid" data-module="media-grid">
             {% for item in list %}
+            {% if item.name not in g.exclude_eov %}
             {% set href = h.url_for(controller='package', action='search', eov=item.name) %}
             {% set label = label_function(item) if label_function else item.display_name %}
             {% set label = _(label) %}
@@ -308,6 +309,7 @@
               <span class="hidden separator"> - </span>
               <span class="item-count badge">{{ count }}</span>
             </li>
+            {% endif %}
             {% endfor %}
           </ul>
           {% endif %}


### PR DESCRIPTION
add ckan.exclude_eov and ckan.exclude_eov_category config options. These allow individual eov's to be excluded or a whole eov category by adding the approprit name to the list in the production.ini file or setting at run time through the admin config page.

example of production.ini entry:
```
ckan.exclude_eov_category = ['Other']
ckan.exclude_eov = ['other']
```