### PR TITLE
add function and reorganize pacific headers to handle multilingual urls in menus

### DIFF
--- a/ckanext/cioos_theme/plugin.py
+++ b/ckanext/cioos_theme/plugin.py
@@ -268,7 +268,8 @@ class Cioos_ThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
             # 'cioos_get_organization_dict_extra': cioos_helpers.get_organization_dict_extra
             'cioos_datasets': cioos_helpers.cioos_datasets,
             'cioos_count_datasets': cioos_helpers.cioos_count_datasets,
-            'cioos_get_eovs': cioos_helpers.cioos_get_eovs
+            'cioos_get_eovs': cioos_helpers.cioos_get_eovs,
+            'cioos_get_locale_url': self.get_locale_url
         }
 
     def get_validators(self):
@@ -565,3 +566,10 @@ class Cioos_ThemePlugin(plugins.SingletonPlugin, DefaultTranslation):
     def lang(self):
         from ckantoolkit import h
         return h.lang()
+
+    def get_locale_url(self, base_url, locale_urls):
+        default_locale = toolkit.config.get('ckan.locale_default', toolkit.config.get('ckan.locales_offered', ['en'])[0])
+        lang = toolkit.h.lang() or default_locale
+        if base_url.endswith('/'):
+            return base_url + locale_urls.get(lang)
+        return base_url + '/' + locale_urls.get(lang)

--- a/ckanext/cioos_theme/templates/pacific_header.html
+++ b/ckanext/cioos_theme/templates/pacific_header.html
@@ -1,72 +1,140 @@
 {% macro include_mobile_header() %}
-  {% block header_mobilesite_navigation2 %}
-  <nav>
-    <ul id="menu-mobile-menu" class="menu">
-      <li id="menu-item-921" class="menu-item  menu-item-home"><a href="{{ g.site_home_url }}"><span>{{_('HOME')}}</span></a></li>
-      <li id="menu-item-920" class="menu-item  menu-item-has-children menu-parent"><a href="{{ g.site_home_url }}about/"><span>{{_('ABOUT')}}</span></a>
-        <ul class="sub-menu">
-          <li id="menu-item-1873" class="menu-item "><a href="{{ g.site_home_url }}about/partners/">{{_('Partners')}}</a></li>
-          <li id="menu-item-1872" class="menu-item "><a href="{{ g.site_home_url }}about/data-management/">{{_('Data Management')}}</a></li>
-          <li id="menu-item-1934" class="menu-item "><a href="{{ g.site_home_url }}about/essential-ocean-variables/">{{_('Essential Ocean Variables')}}</a></li>
-        </ul>
-      </li>
-      <li id="menu-item-1673" class="menu-item  menu-item-has-children menu-parent"><a href="{{ g.site_home_url }}data-applications/"><span>{{_('APPLIED DATA')}}</span></a>
-        <ul class="sub-menu">
-          <li id="menu-item-1743" class="menu-item "><a href="{{ g.site_home_url }}data-applications/baynes-sound/">{{_('Baynes Sound Ecosystem Monitoring')}}</a></li>
-          <li id="menu-item-1940" class="menu-item "><a href="{{ g.site_home_url }}under-construction/">{{_('Marine Heatwaves')}}</a></li>
-          <li id="menu-item-1942" class="menu-item "><a href="{{ g.site_home_url }}under-construction/">{{_('Ocean Climate')}}</a></li>
-          <li id="menu-item-1941" class="menu-item "><a href="{{ g.site_home_url }}under-construction/">{{_('Strait of Georgia Currents')}}</a></li>
-        </ul>
-      </li>
-      <li id="menu-item-1359" class="menu-item "><a href="{{ g.site_home_url }}data-tools/"><span>{{_('DATA TOOLS')}}</span></a></li>
-      <li id="menu-item-1652" class="menu-item menu-item-has-children menu-parent current-menu-item current_page_item"><a href="{{ h.url_for('home.index') }}"><span>{{_('DATA CATALOGUE')}}</span></a>
-        <ul class="sub-menu">
-          <li id="menu-item-1999" class="menu-item"><a href="{{ h.url_for('home.index') }}dataset">{{_('Datasets')}}</a></li>
-          <li id="menu-item-2001" class="menu-item"><a href="{{ h.url_for('home.index') }}organization">{{_('Organizations')}}</a></li>
-        </ul>
-      </li>
-      <ul class="shareicons">
-        <li><a href="http://twitter.com/cioos_siooc" tabindex="0" aria-label="Twitter"><i class="fa fa-twitter"></i></a></li>
-        <li>
-          {%- if h.lang() == 'en' -%}
-            <a href="{% url_for h.current_url(), locale='fr' %}" tabindex="0" aria-label="French/English">FR</a>
-          {%- else -%}
-            <a href="{% url_for h.current_url(), locale='en' %}" tabindex="0" aria-label="French/English">EN</a>
-          {%- endif -%}
+{% block header_mobilesite_navigation2 %}
+<nav>
+  <ul id="menu-mobile-menu" class="menu">
+    <li id="menu-item-921" class="menu-item  menu-item-home">
+      <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'', 'fr':'fr/'}) }}">
+        <span>{{_('HOME')}}</span>
+      </a>
+    </li>
+    <li id="menu-item-920" class="menu-item  menu-item-has-children menu-parent">
+      <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'about/', 'fr':'fr/a-propos/'}) }}about/">
+        <span>{{_('ABOUT')}}</span>
+      </a>
+      <ul class="sub-menu">
+        <li id="menu-item-1873" class="menu-item ">
+          <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'about/partners/', 'fr':'fr/a-propos/partenaires/'}) }}">{{_('Partners')}}</a>
+        </li>
+        <li id="menu-item-1872" class="menu-item ">
+          <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'about/data-management/', 'fr':'fr/a-propos/gestion-de-donnees/'}) }}">{{_('Data Management')}}</a>
+        </li>
+        <li id="menu-item-1934" class="menu-item ">
+          <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'about/essential-ocean-variables/', 'fr':'fr/a-propos/variables-oceaniques-essentielles/'}) }}">{{_('Essential Ocean Variables')}}</a>
         </li>
       </ul>
+    </li>
+    <li id="menu-item-1673" class="menu-item  menu-item-has-children menu-parent">
+      <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'data-applications/', 'fr':'fr/application-de-donnees/'}) }}">
+        <span>{{_('APPLIED DATA')}}</span>
+      </a>
+      <ul class="sub-menu">
+        <li id="menu-item-1743" class="menu-item ">
+          <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'applied-data/baynes-sound/', 'fr':'fr/application-de-donnees/surveillance-de-lecosysteme-de-baynes-sound/'}) }}">{{_('Baynes Sound Ecosystem Monitoring')}}</a>
+        </li>
+        <li id="menu-item-1940" class="menu-item ">
+          <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'applied-data/marine-heatwave-monitor/', 'fr':'fr/application-de-donnees/vagues-de-chaleur-marines/'}) }}">{{_('Marine Heatwaves')}}</a>
+        </li>
+        <li id="menu-item-1942" class="menu-item ">
+          <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'applied-data/station-papa/', 'fr':'fr/application-de-donnees/climat-des-oceans/'}) }}">{{_('Ocean Climate')}}</a>
+        </li>
+        <li id="menu-item-1941" class="menu-item ">
+          <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'applied-data/sog-currents/', 'fr':'fr/application-de-donnees/les-courants-du-detroit-de-georgie/'}) }}">{{_('Strait of Georgia Currents')}}</a>
+        </li>
+      </ul>
+    </li>
+    <li id="menu-item-1359" class="menu-item ">
+      <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'data-tools/', 'fr':'fr/outils-de-donnees/'}) }}">
+        <span>{{_('DATA TOOLS')}}</span>
+      </a>
+    </li>
+    <li id="menu-item-1652" class="menu-item menu-item-has-children menu-parent current-menu-item current_page_item">
+      <a href="{{ h.url_for('home.index') }}">
+        <span>{{_('DATA CATALOGUE')}}</span>
+      </a>
+      <ul class="sub-menu">
+        <li id="menu-item-1999" class="menu-item">
+          <a href="{{ h.url_for('home.index') }}dataset">{{_('Datasets')}}</a>
+        </li>
+        <li id="menu-item-2001" class="menu-item">
+          <a href="{{ h.url_for('home.index') }}organization">{{_('Organizations')}}</a>
+        </li>
+      </ul>
+    </li>
+    <ul class="shareicons">
+      <li><a href="http://twitter.com/cioos_siooc" tabindex="0" aria-label="Twitter"><i class="fa fa-twitter"></i></a>
+      </li>
+      <li>
+        {%- if h.lang() == 'en' -%}
+        <a href="{% url_for h.current_url(), locale='fr' %}" tabindex="0" aria-label="French/English">FR</a>
+        {%- else -%}
+        <a href="{% url_for h.current_url(), locale='en' %}" tabindex="0" aria-label="French/English">EN</a>
+        {%- endif -%}
+      </li>
     </ul>
-  </nav>
-  {% endblock %}
+  </ul>
+</nav>
+{% endblock %}
 {% endmacro %}
 
 
 {% macro include_site_header() %}
-  {% block header_main %}
-  <ul id="menu-main-menu-en" class="menu">
-    <li id="menu-item-921" class="menu-item  menu-item-home"><a href="{{ g.site_home_url }}"><span>{{_('HOME')}}</span></a></li>
-    <li id="menu-item-920" class="menu-item  menu-item-has-children menu-parent"><a href="{{ g.site_home_url }}about/"><span class="mega-indicator">{{_('ABOUT')}}</span></a>
-      <ul class="sub-menu" style=" min-width: 94px;">
-        <li id="menu-item-1873" class="menu-item "><a href="{{ g.site_home_url }}about/partners/">{{_('Partners')}}</a></li>
-        <li id="menu-item-1872" class="menu-item "><a href="{{ g.site_home_url }}about/data-management/">{{_('Data Management')}}</a></li>
-        <li id="menu-item-1934" class="menu-item "><a href="{{ g.site_home_url }}about/essential-ocean-variables/">{{_('Essential Ocean Variables')}}</a></li>
-      </ul>
-    </li>
-    <li id="menu-item-1673" class="menu-item  menu-item-has-children menu-parent"><a href="{{ g.site_home_url }}data-applications/"><span class="mega-indicator">{{_('APPLIED DATA')}}</span></a>
-      <ul class="sub-menu" style=" min-width: 144px;">
-        <li id="menu-item-1743" class="menu-item "><a href="{{ g.site_home_url }}data-applications/baynes-sound/">{{_('Baynes Sound Ecosystem Monitoring')}}</a></li>
-        <li id="menu-item-1940" class="menu-item "><a href="{{ g.site_home_url }}under-construction/">{{_('Marine Heatwaves')}}</a></li>
-        <li id="menu-item-1942" class="menu-item "><a href="{{ g.site_home_url }}under-construction/">{{_('Ocean Climate')}}</a></li>
-        <li id="menu-item-1941" class="menu-item "><a href="{{ g.site_home_url }}under-construction/">{{_('Strait of Georgia Currents')}}</a></li>
-      </ul>
-    </li>
-    <li id="menu-item-1359" class="menu-item "><a href="{{ g.site_home_url }}data-tools/"><span>{{_('DATA TOOLS')}}</span></a></li>
-    <li id="menu-item-1652" class="menu-item menu-item-has-children menu-parent current-menu-item current_page_item"><a href="{{ h.url_for('home.index') }}"><span class="mega-indicator">{{_('DATA CATALOGUE')}}</span></a>
-      <ul class="sub-menu" style=" min-width: 161px;">
-        <li id="menu-item-1999" class="menu-item"><a href="{{ h.url_for('home.index') }}dataset">{{_('Datasets')}}</a></li>
-        <li id="menu-item-2001" class="menu-item"><a href="{{ h.url_for('home.index') }}organization">{{_('Organizations')}}</a></li>
-      </ul>
-    </li>
-  </ul>
-  {% endblock %}
+{% block header_main %}
+<ul id="menu-main-menu-en" class="menu">
+  <li id="menu-item-921" class="menu-item  menu-item-home">
+    <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'', 'fr':'fr/'}) }}">
+      <span>{{_('HOME')}}</span>
+    </a>
+  </li>
+  <li id="menu-item-920" class="menu-item  menu-item-has-children menu-parent">
+    <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'about/', 'fr':'fr/a-propos/'}) }}"><span class="mega-indicator">{{_('ABOUT')}}</span>
+    </a>
+    <ul class="sub-menu" style=" min-width: 94px;">
+      <li id="menu-item-1873" class="menu-item ">
+        <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'about/partners/', 'fr':'fr/a-propos/partenaires/'}) }}">{{_('Partners')}}</a>
+      </li>
+      <li id="menu-item-1872" class="menu-item ">
+        <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'about/data-management', 'fr':'fr/a-propos/gestion-de-donnees/'}) }}">{{_('Data Management')}}</a>
+      </li>
+      <li id="menu-item-1934" class="menu-item ">
+        <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'about/essential-ocean-variables', 'fr':'fr/a-propos/variables-oceaniques-essentielles/'}) }}">{{_('Essential Ocean Variables')}}</a>
+      </li>
+    </ul>
+  </li>
+  <li id="menu-item-1673" class="menu-item  menu-item-has-children menu-parent">
+    <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'data-applications', 'fr':'fr/application-de-donnees/'})  }}"><span class="mega-indicator">{{_('APPLIED DATA')}}</span>
+    </a>
+    <ul class="sub-menu" style=" min-width: 144px;">
+      <li id="menu-item-1743" class="menu-item ">
+        <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'applied-data/baynes-sound/', 'fr':'fr/application-de-donnees/surveillance-de-lecosysteme-de-baynes-sound/'}) }}">{{_('Baynes Sound Ecosystem Monitoring')}}</a>
+      </li>
+      <li id="menu-item-1940" class="menu-item ">
+        <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'applied-data/marine-heatwave-monitor/', 'fr':'fr/application-de-donnees/vagues-de-chaleur-marines/'}) }}">{{_('Marine Heatwaves')}}</a>
+      </li>
+      <li id="menu-item-1942" class="menu-item ">
+        <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'applied-data/station-papa/', 'fr':'fr/application-de-donnees/climat-des-oceans/'}) }}">{{_('Ocean Climate')}}</a>
+      </li>
+      <li id="menu-item-1941" class="menu-item ">
+        <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'applied-data/sog-currents/', 'fr':'fr/application-de-donnees/les-courants-du-detroit-de-georgie/'}) }}">{{_('Strait of Georgia Currents')}}</a>
+      </li>
+    </ul>
+  </li>
+  <li id="menu-item-1359" class="menu-item ">
+    <a href="{{ h.cioos_get_locale_url(g.site_home_url, {'en':'data-tools/', 'fr':'fr/outils-de-donnees/'}) }}">
+      <span>{{_('DATA TOOLS')}}</span>
+    </a>
+  </li>
+  <li id="menu-item-1652" class="menu-item menu-item-has-children menu-parent current-menu-item current_page_item">
+    <a href="{{ h.url_for('home.index') }}"><span class="mega-indicator">{{_('DATA CATALOGUE')}}</span>
+    </a>
+    <ul class="sub-menu" style=" min-width: 161px;">
+      <li id="menu-item-1999" class="menu-item">
+        <a href="{{ h.url_for('home.index') }}dataset">{{_('Datasets')}}</a>
+      </li>
+      <li id="menu-item-2001" class="menu-item">
+        <a href="{{ h.url_for('home.index') }}organization">{{_('Organizations')}}</a>
+      </li>
+    </ul>
+  </li>
+</ul>
+{% endblock %}
 {% endmacro %}


### PR DESCRIPTION
This approach seemed like the best mix of simplicity, flexibility, and code reuse. Open to suggestions if anyone sees a better way to do this. urls are hardcoded in the menu template and a helper function is used to concatenate the base url with the appropriate slug based on the current language selected.